### PR TITLE
Add SVG support

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -8,6 +8,9 @@ const tests = {
 		'basic': {
 			message: 'supports basic usage'
 		},
+		'svg': {
+			message: 'inline svg files with the correct mime type',
+		},
 		'basic:errors': {
 			message: 'supports { errors: "throw" } option',
 			options: {

--- a/lib/default-transforms.js
+++ b/lib/default-transforms.js
@@ -4,6 +4,8 @@ export default {
 			return node.tag === 'img' && node.attrs && node.attrs.src;
 		},
 		transform(node, data) {
+			if (node.attrs.src.endsWith('.svg'))
+				data.mime = 'image/svg+xml';
 			node.attrs.src = `data:${data.mime};base64,${data.buffer.toString('base64')}`;
 		}
 	},

--- a/test/svg.expect.html
+++ b/test/svg.expect.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<title>PostHTML Inline Assets: SVG Files</title>
+
+<h1>PostHTML Inline Assets: SVG Files</h1>
+<img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEiPjxjaXJjbGUgcj0iNCIgY3k9IjQiIGN4PSI0IiB0cmFuc2Zvcm09InNjYWxlKDE1KSIvPjwvc3ZnPgo=">

--- a/test/svg.html
+++ b/test/svg.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<title>PostHTML Inline Assets: SVG Files</title>
+
+<h1>PostHTML Inline Assets: SVG Files</h1>
+<img src="svg.svg">

--- a/test/svg.svg
+++ b/test/svg.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1"><circle r="4" cy="4" cx="4" transform="scale(15)"/></svg>


### PR DESCRIPTION
Hi!

Currently `posthtml-inline-assets` returns the wrong mime-type for inline SVG images.

@Shuunen ran into this issue and reported it in my parcel plugin: shff/parcel-plugin-inliner#8 & shff/parcel-plugin-inliner#9

This is an issue with file-type, but the author mentioned in two issues that he's not interested in changing the current behavior: sindresorhus/file-type#32 and sindresorhus/file-type#58.

I just added a small check in the image transform that changes the mime type when the extension is SVG.

### Before

```html
<img class="icon" src="data:application/xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJmZWF0aGVyIGZlYXRoZXItZ2l0aHViIj48cGF0aCBkPSJNOSAxOWMtNSAxLjUtNS0yLjUtNy0zbTE0IDZ2LTMuODdhMy4zNyAzLjM3IDAgMCAwLS45NC0yLjYxYzMuMTQtLjM1IDYuNDQtMS41NCA2LjQ0LTdBNS40NCA1LjQ0IDAgMCAwIDIwIDQuNzcgNS4wNyA1LjA3IDAgMCAwIDE5LjkxIDFTMTguNzMuNjUgMTYgMi40OGExMy4zOCAxMy4zOCAwIDAgMC03IDBDNi4yNy42NSA1LjA5IDEgNS4wOSAxQTUuMDcgNS4wNyAwIDAgMCA1IDQuNzdhNS40NCA1LjQ0IDAgMCAwLTEuNSAzLjc4YzAgNS40MiAzLjMgNi42MSA2LjQ0IDdBMy4zNyAzLjM3IDAgMCAwIDkgMTguMTNWMjIiPjwvcGF0aD48L3N2Zz4=">
```

### After

```html
<img class="icon" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJmZWF0aGVyIGZlYXRoZXItZ2l0aHViIj48cGF0aCBkPSJNOSAxOWMtNSAxLjUtNS0yLjUtNy0zbTE0IDZ2LTMuODdhMy4zNyAzLjM3IDAgMCAwLS45NC0yLjYxYzMuMTQtLjM1IDYuNDQtMS41NCA2LjQ0LTdBNS40NCA1LjQ0IDAgMCAwIDIwIDQuNzcgNS4wNyA1LjA3IDAgMCAwIDE5LjkxIDFTMTguNzMuNjUgMTYgMi40OGExMy4zOCAxMy4zOCAwIDAgMC03IDBDNi4yNy42NSA1LjA5IDEgNS4wOSAxQTUuMDcgNS4wNyAwIDAgMCA1IDQuNzdhNS40NCA1LjQ0IDAgMCAwLTEuNSAzLjc4YzAgNS40MiAzLjMgNi42MSA2LjQ0IDdBMy4zNyAzLjM3IDAgMCAwIDkgMTguMTNWMjIiPjwvcGF0aD48L3N2Zz4=">
```
