### PR TITLE
fix(image): don't transform if already an image with `src=data:`

### DIFF
--- a/lib/default-transforms.js
+++ b/lib/default-transforms.js
@@ -1,7 +1,7 @@
 export default {
 	image: {
 		resolve(node) {
-			return node.tag === 'img' && node.attrs && node.attrs.src;
+			return node.tag === 'img' && node.attrs && node.attrs.src && !node.attrs.src.startsWith("data:") && node.attrs.src;
 		},
 		transform(node, data) {
 			if (node.attrs.src.endsWith('.svg'))


### PR DESCRIPTION
only transform if the image src does not start with `data:`.
kept the `node.attrs.src` in case it's undefined.